### PR TITLE
doc: add pull request template file

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+
+## Description
+
+[Describe the changes you've made and how they address the issue or feature request.]
+
+## Reason for change
+
+[Why did you make the change]
+
+## Checklist
+
+- [ ] I have added/updated tests for this change (if applicable).
+- [ ] I have updated the documentation (if applicable).
+- [ ] This PR doesn't contain any unrelated changes.
+
+## References
+
+[Add any relevant links or references that support the changes made.]  


### PR DESCRIPTION
## What does this PR do?

- Adds PR template file to describe PRs

## Reason for change?

- To ensure PRs are well documented and standardized.